### PR TITLE
Remove business cashback from programs

### DIFF
--- a/src/components/business/ProgramBuilder.tsx
+++ b/src/components/business/ProgramBuilder.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PlusCircle, MinusCircle, Award, Check, ChevronRight, ChevronLeft, Star, Gift, Zap } from 'lucide-react';
+import { PlusCircle, MinusCircle, Award, Check, ChevronRight, ChevronLeft, Star, Gift } from 'lucide-react';
 import type { LoyaltyProgram, ProgramType, RewardTier } from '../../types/loyalty';
 import { useBusinessCurrency } from '../../contexts/BusinessCurrencyContext';
 
@@ -175,12 +175,6 @@ export const ProgramBuilder: React.FC<ProgramBuilderProps> = ({ initialProgram, 
                 title={t('business.Stamps')} 
                 description={t('business.Digital punch card: one stamp per visit or purchase, simple and effective')}
                 icon={<Check className="w-6 h-6 text-green-500" />}
-              />
-              <ProgramTypeCard 
-                type="CASHBACK" 
-                title={t('business.Cashback')} 
-                description={t('business.Customers earn a percentage back from each purchase to use on future orders')}
-                icon={<Zap className="w-6 h-6 text-yellow-500" />}
               />
             </div>
 


### PR DESCRIPTION
Remove Cashback program type option from Program Builder to align with business rules.

---
<a href="https://cursor.com/background-agent?bcId=bc-751d40a0-1288-4a7b-934a-37a40baaf438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-751d40a0-1288-4a7b-934a-37a40baaf438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

