### PR TITLE
Enhance csrf token security and add expiry

### DIFF
--- a/src/utils/csrf.ts
+++ b/src/utils/csrf.ts
@@ -1,65 +1,70 @@
-// Minimal CSRF protection utilities (non-invasive)
+// Enhanced CSRF protection utilities with crypto.randomBytes only and expiration
 // Client: send X-CSRF-Token header from a cookie value
-// Server: validate header matches cookie (double-submit pattern)
+// Server: validate header matches cookie (double-submit pattern) with expiration
 
 import crypto from 'crypto';
 
 export const CSRF_COOKIE_NAME = 'csrf_token';
 export const CSRF_HEADER_NAME = 'x-csrf-token';
+export const CSRF_TOKEN_EXPIRY_MINUTES = 15;
 
-// Generate a cryptographically secure CSRF token with proper fallbacks
-export function generateCsrfToken(): string {
-  try {
-    // Primary method: Use crypto.randomBytes for maximum security
-    if (crypto && typeof crypto.randomBytes === 'function') {
-      return crypto.randomBytes(32).toString('hex');
-    }
-  } catch (error) {
-    console.warn('crypto.randomBytes not available, trying fallback methods');
-  }
-
-  try {
-    // Fallback 1: Use crypto.randomUUID if available
-    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
-      // @ts-ignore - randomUUID may not be in all crypto type definitions
-      return crypto.randomUUID();
-    }
-  } catch (error) {
-    console.warn('crypto.randomUUID not available, trying final fallback');
-  }
-
-  try {
-    // Fallback 2: Use Web Crypto API if available (browser environment)
-    if (typeof globalThis !== 'undefined' && globalThis.crypto && globalThis.crypto.getRandomValues) {
-      const array = new Uint8Array(32);
-      globalThis.crypto.getRandomValues(array);
-      return Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('');
-    }
-  } catch (error) {
-    console.warn('Web Crypto API not available, using timestamp-based fallback');
-  }
-
-  // Final fallback: Timestamp + process hrtime (better than Math.random)
-  // This is cryptographically weak but better than Math.random()
-  try {
-    if (typeof process !== 'undefined' && process.hrtime) {
-      const hrTime = process.hrtime();
-      const timestamp = Date.now().toString(36);
-      const nanoTime = (hrTime[0] * 1e9 + hrTime[1]).toString(36);
-      return `${timestamp}_${nanoTime}_${Date.now().toString(16)}`;
-    }
-  } catch {
-    // Fall through to absolute final fallback
-  }
-
-  // Absolute final fallback: Enhanced timestamp-based token (avoid Math.random)
-  const timestamp = Date.now();
-  const performanceNow = typeof performance !== 'undefined' ? performance.now() : 0;
-  const randomValue = timestamp ^ (performanceNow * 1000000);
-  return `${timestamp.toString(36)}_${randomValue.toString(36)}_${(timestamp + performanceNow).toString(16)}`;
+// Token structure: {token}.{timestamp}
+interface CsrfTokenData {
+  token: string;
+  timestamp: number;
 }
 
-// Express-style middleware signature kept generic to avoid importing express types
+// Generate a cryptographically secure CSRF token using crypto.randomBytes only
+export function generateCsrfToken(): string {
+  try {
+    // Use crypto.randomBytes for maximum security - no fallbacks
+    const randomToken = crypto.randomBytes(32).toString('hex');
+    const timestamp = Date.now();
+    return `${randomToken}.${timestamp}`;
+  } catch (error) {
+    throw new Error('CSRF token generation failed: crypto.randomBytes not available');
+  }
+}
+
+// Parse token and validate expiration
+export function parseCsrfToken(tokenString: string): CsrfTokenData | null {
+  try {
+    const parts = tokenString.split('.');
+    if (parts.length !== 2) {
+      return null;
+    }
+    
+    const token = parts[0];
+    const timestamp = parseInt(parts[1], 10);
+    
+    if (!token || isNaN(timestamp)) {
+      return null;
+    }
+    
+    return { token, timestamp };
+  } catch {
+    return null;
+  }
+}
+
+// Check if token is expired (15 minutes)
+export function isCsrfTokenExpired(tokenData: CsrfTokenData): boolean {
+  const now = Date.now();
+  const expiryTime = tokenData.timestamp + (CSRF_TOKEN_EXPIRY_MINUTES * 60 * 1000);
+  return now > expiryTime;
+}
+
+// Validate CSRF token with expiration check
+export function validateCsrfToken(tokenString: string): boolean {
+  const tokenData = parseCsrfToken(tokenString);
+  if (!tokenData) {
+    return false;
+  }
+  
+  return !isCsrfTokenExpired(tokenData);
+}
+
+// Enhanced CSRF middleware with expiration validation
 export function csrfMiddleware(req: any, res: any, next: any) {
   try {
     // Only enforce on state-changing methods
@@ -84,27 +89,52 @@ export function csrfMiddleware(req: any, res: any, next: any) {
     });
     const cookieToken = cookies[CSRF_COOKIE_NAME];
 
-    if (!headerToken || !cookieToken || headerToken !== cookieToken) {
-      return res.status(403).json({ error: 'CSRF validation failed' });
+    // Enhanced validation with expiration check
+    if (!headerToken || !cookieToken) {
+      return res.status(403).json({ error: 'CSRF token missing' });
     }
+
+    if (headerToken !== cookieToken) {
+      return res.status(403).json({ error: 'CSRF token mismatch' });
+    }
+
+    // Validate token format and expiration
+    if (!validateCsrfToken(headerToken)) {
+      return res.status(403).json({ error: 'CSRF token expired or invalid' });
+    }
+
     return next();
   } catch (e) {
     return res.status(403).json({ error: 'CSRF validation error' });
   }
 }
 
-// Helper to set CSRF cookie if missing (to be called on safe GET to /api/*)
+// Helper to set CSRF cookie if missing or expired (to be called on safe GET to /api/*)
 export function ensureCsrfCookie(req: any, res: any, next: any) {
   try {
     const cookieHeader: string = req.headers?.cookie || '';
-    const hasCookie = cookieHeader.includes(`${CSRF_COOKIE_NAME}=`);
-    if (!hasCookie) {
+    const cookies: Record<string, string> = {};
+    cookieHeader.split(';').forEach(pair => {
+      const [k, v] = pair.split('=');
+      if (k && v) cookies[k.trim()] = decodeURIComponent(v.trim());
+    });
+    
+    const existingToken = cookies[CSRF_COOKIE_NAME];
+    let needsNewToken = !existingToken;
+    
+    // Check if existing token is expired
+    if (existingToken && !validateCsrfToken(existingToken)) {
+      needsNewToken = true;
+    }
+    
+    if (needsNewToken) {
       const token = generateCsrfToken();
       // Set cookie with SameSite=Lax so it is sent on top-level navigations within site
-      res.setHeader('Set-Cookie', `${CSRF_COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; SameSite=Lax; Secure`);
+      // Add HttpOnly for additional security
+      res.setHeader('Set-Cookie', `${CSRF_COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; SameSite=Lax; Secure; HttpOnly`);
     }
-  } catch {
-    // ignore
+  } catch (error) {
+    console.warn('Failed to set CSRF cookie:', error);
   } finally {
     next();
   }


### PR DESCRIPTION
Improve CSRF token generation and validation by using `crypto.randomBytes` only, adding a 15-minute expiration, and strengthening validation checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a7c0e36-1125-4329-b961-797e8842b888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a7c0e36-1125-4329-b961-797e8842b888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

